### PR TITLE
Upgrade chrono to 0.4.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT/Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-chrono = "0.4.11"
+chrono = "0.4.13"
 time = "0.1.43"
 
 [lib]


### PR DESCRIPTION
Chrono Version
https://github.com/chronotope/chrono/releases/tag/v0.4.13